### PR TITLE
Add support for TF 13, AWS provider 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@
 
 Creates the relevant infrastructure needed to handle AWS S3 file uploads.
 
+## Terraform Versions
+
+Terraform 0.13. Pin module version to ~> x.x. Submit pull-requests to main branch.
+
+Terraform 0.12. Pin module version to ~> x.x. Submit pull-requests to terraform012 branch.
+
 ## Anti-virus Scanning
 
 Anti-virus scanning is handled via an AWS Lambda function using

--- a/README.md
+++ b/README.md
@@ -37,14 +37,14 @@ aws s3 cp bucket-antivirus-function/build/lambda.zip "s3://${lambda_s3_bucket}/a
 
 | Name | Version |
 |------|---------|
-| terraform | ~> 0.12.0 |
-| aws | ~> 2.70 |
+| terraform | ~> 0.13.0 |
+| aws | ~> 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.70 |
+| aws | ~> 3.0 |
 
 ## Inputs
 

--- a/av.tf
+++ b/av.tf
@@ -1,6 +1,6 @@
 module "s3_anti_virus" {
   source  = "trussworks/s3-anti-virus/aws"
-l version = "~>3.0.0"
+  version = "~>3.0.0"
 
   lambda_s3_bucket = var.lambda_s3_bucket
   lambda_version   = "2.0.0"

--- a/av.tf
+++ b/av.tf
@@ -1,6 +1,6 @@
 module "s3_anti_virus" {
   source  = "trussworks/s3-anti-virus/aws"
-  version = "~>2.1.0"
+l version = "~>3.0.0"
 
   lambda_s3_bucket = var.lambda_s3_bucket
   lambda_version   = "2.0.0"
@@ -26,7 +26,7 @@ module "s3_anti_virus" {
 #
 module "virus_scan_s3_bucket" {
   source         = "trussworks/s3-private-bucket/aws"
-  version        = "~>2.1.0"
+  version        = "~>3.2.0"
   bucket         = var.virus_scanning_bucket
   logging_bucket = module.file_uploads_s3_logging_bucket.aws_logs_bucket
 

--- a/s3.tf
+++ b/s3.tf
@@ -3,7 +3,7 @@
 #
 module "file_uploads_s3_bucket" {
   source         = "trussworks/s3-private-bucket/aws"
-  version        = "~>2.1.0"
+  version        = "~>3.2.0"
   bucket         = var.file_uploads_bucket
   logging_bucket = module.file_uploads_s3_logging_bucket.aws_logs_bucket
 
@@ -19,7 +19,7 @@ module "file_uploads_s3_bucket" {
 # we use a separate access logging bucket for every environment
 module "file_uploads_s3_logging_bucket" {
   source  = "trussworks/logs/aws"
-  version = "~> 8.0.0"
+  version = "~> 10.0.0"
   region  = var.region
 
   s3_bucket_name = local.file_uploads_s3_bucket_logs

--- a/s3.tf
+++ b/s3.tf
@@ -20,7 +20,6 @@ module "file_uploads_s3_bucket" {
 module "file_uploads_s3_logging_bucket" {
   source  = "trussworks/logs/aws"
   version = "~> 10.0.0"
-  region  = var.region
 
   s3_bucket_name = local.file_uploads_s3_bucket_logs
 

--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,10 @@
 terraform {
-  required_version = "~> 0.12.0"
+  required_version = "~> 0.13.0"
 
   required_providers {
-    aws = "~> 2.70"
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.0"
+    }
   }
 }


### PR DESCRIPTION
* Update the child modules to versions that support TF 13, AWS provider 3
* Create terraform012 branch and add the boilerplate note about TF versions to the README. We can update the reference to pinned versions once versions have been released.