### PR TITLE
Add option to use existing log bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,11 @@ aws s3 cp bucket-antivirus-function/build/lambda.zip "s3://${lambda_s3_bucket}/a
 | av\_status\_sns\_arn | SNS topic ARN to publish scan results to | `string` | n/a | yes |
 | cloudwatch\_logs\_retention\_days | Number of days to keep logs in AWS CloudWatch. | `string` | `90` | no |
 | cors\_rules | List of maps containing rules for Cross-Origin Resource Sharing. | `list(any)` | `[]` | no |
+| create\_logging\_bucket | Whether to create a new bucket for S3 access logs. | `bool` | `false` | no |
 | environment | Environment level. | `string` | `"dev"` | no |
 | file\_uploads\_bucket | The name of the S3 bucket used to store the uploads. | `string` | n/a | yes |
 | lambda\_s3\_bucket | The name of the S3 bucket where the lambda build artifact is stored | `string` | n/a | yes |
+| logging\_bucket | The name of the S3 bucket used for S3 access logs. | `string` | n/a | yes |
 | region | Application region. | `string` | `"us-west-2"` | no |
 | s3\_logs\_retention\_days | Number of days to keep logs in S3. | `string` | `90` | no |
 | tags | A map of tags to add to all resources. | `map(string)` | `{}` | no |

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ aws s3 cp bucket-antivirus-function/build/lambda.zip "s3://${lambda_s3_bucket}/a
 | environment | Environment level. | `string` | `"dev"` | no |
 | file\_uploads\_bucket | The name of the S3 bucket used to store the uploads. | `string` | n/a | yes |
 | lambda\_s3\_bucket | The name of the S3 bucket where the lambda build artifact is stored | `string` | n/a | yes |
-| logging\_bucket | The name of the S3 bucket used for S3 access logs. | `string` | n/a | yes |
+| logging\_bucket | The name of the S3 bucket used for S3 access logs. | `string` | `""` | no |
 | region | Application region. | `string` | `"us-west-2"` | no |
 | s3\_logs\_retention\_days | Number of days to keep logs in S3. | `string` | `90` | no |
 | tags | A map of tags to add to all resources. | `map(string)` | `{}` | no |

--- a/av.tf
+++ b/av.tf
@@ -30,7 +30,7 @@ module "virus_scan_s3_bucket" {
   source         = "trussworks/s3-private-bucket/aws"
   version        = "~>3.2.0"
   bucket         = var.virus_scanning_bucket
-  logging_bucket = var.create_logging_bucket ? module.file_uploads_s3_logging_bucket.aws_logs_bucket : var.logging_bucket
+  logging_bucket = var.create_logging_bucket ? module.file_uploads_s3_logging_bucket.aws_logs_bucket : local.file_uploads_s3_logging_bucket
 
   tags = {
     Name        = "S3 bucket for virus scanning"

--- a/av.tf
+++ b/av.tf
@@ -30,7 +30,7 @@ module "virus_scan_s3_bucket" {
   source         = "trussworks/s3-private-bucket/aws"
   version        = "~>3.2.0"
   bucket         = var.virus_scanning_bucket
-  logging_bucket = var.create_logging_bucket ? module.file_uploads_s3_logging_bucket.aws_logs_bucket : local.file_uploads_s3_logging_bucket
+  logging_bucket = var.create_logging_bucket ? module.file_uploads_s3_logging_bucket.aws_logs_bucket : local.file_uploads_s3_bucket_logs
 
   tags = {
     Name        = "S3 bucket for virus scanning"

--- a/av.tf
+++ b/av.tf
@@ -30,7 +30,7 @@ module "virus_scan_s3_bucket" {
   source         = "trussworks/s3-private-bucket/aws"
   version        = "~>3.2.0"
   bucket         = var.virus_scanning_bucket
-  logging_bucket = module.file_uploads_s3_logging_bucket.aws_logs_bucket
+  logging_bucket = var.create_logging_bucket ? module.file_uploads_s3_logging_bucket.aws_logs_bucket : var.logging_bucket
 
   tags = {
     Name        = "S3 bucket for virus scanning"

--- a/main.tf
+++ b/main.tf
@@ -8,5 +8,5 @@ data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
 
 locals {
-  antivirus_version           = "2.0.0"
+  antivirus_version = "2.0.0"
 }

--- a/main.tf
+++ b/main.tf
@@ -8,5 +8,6 @@ data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
 
 locals {
-  antivirus_version = "2.0.0"
+  file_uploads_s3_bucket_logs = var.logging_bucket == "" ? "${var.application_name}-${var.environment}-${var.file_uploads_bucket}-logs" : var.logging_bucket
+  antivirus_version           = "2.0.0"
 }

--- a/main.tf
+++ b/main.tf
@@ -8,6 +8,5 @@ data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
 
 locals {
-  file_uploads_s3_bucket_logs = "${var.application_name}-${var.environment}-${var.file_uploads_bucket}-logs"
   antivirus_version           = "2.0.0"
 }

--- a/s3.tf
+++ b/s3.tf
@@ -18,7 +18,7 @@ module "file_uploads_s3_bucket" {
 
 # we use a separate access logging bucket for every environment
 module "file_uploads_s3_logging_bucket" {
-  count = var.create_logging_bucket ? 1 : 0
+  count   = var.create_logging_bucket ? 1 : 0
   source  = "trussworks/logs/aws"
   version = "~> 10.0.0"
 

--- a/s3.tf
+++ b/s3.tf
@@ -5,7 +5,7 @@ module "file_uploads_s3_bucket" {
   source         = "trussworks/s3-private-bucket/aws"
   version        = "~>3.2.0"
   bucket         = var.file_uploads_bucket
-  logging_bucket = var.create_logging_bucket ? module.file_uploads_s3_logging_bucket.aws_logs_bucket : var.logging_bucket
+  logging_bucket = var.create_logging_bucket ? module.file_uploads_s3_logging_bucket.aws_logs_bucket : local.file_uploads_s3_logging_bucket
 
   cors_rules = var.cors_rules
 
@@ -21,7 +21,7 @@ module "file_uploads_s3_logging_bucket" {
   source  = "trussworks/logs/aws"
   version = "~> 10.0.0"
 
-  s3_bucket_name          = var.logging_bucket
+  s3_bucket_name          = local.file_uploads_s3_logging_bucket
   s3_log_bucket_retention = var.s3_logs_retention_days
 
   default_allow = false

--- a/s3.tf
+++ b/s3.tf
@@ -5,7 +5,7 @@ module "file_uploads_s3_bucket" {
   source         = "trussworks/s3-private-bucket/aws"
   version        = "~>3.2.0"
   bucket         = var.file_uploads_bucket
-  logging_bucket = module.file_uploads_s3_logging_bucket.aws_logs_bucket
+  logging_bucket = var.create_logging_bucket ? module.file_uploads_s3_logging_bucket.aws_logs_bucket : var.logging_bucket
 
   cors_rules = var.cors_rules
 
@@ -18,10 +18,11 @@ module "file_uploads_s3_bucket" {
 
 # we use a separate access logging bucket for every environment
 module "file_uploads_s3_logging_bucket" {
+  count = var.create_logging_bucket ? 1 : 0
   source  = "trussworks/logs/aws"
   version = "~> 10.0.0"
 
-  s3_bucket_name          = local.file_uploads_s3_bucket_logs
+  s3_bucket_name          = var.logging_bucket
   s3_log_bucket_retention = var.s3_logs_retention_days
 
   default_allow = false

--- a/s3.tf
+++ b/s3.tf
@@ -5,7 +5,7 @@ module "file_uploads_s3_bucket" {
   source         = "trussworks/s3-private-bucket/aws"
   version        = "~>3.2.0"
   bucket         = var.file_uploads_bucket
-  logging_bucket = var.create_logging_bucket ? module.file_uploads_s3_logging_bucket.aws_logs_bucket : local.file_uploads_s3_logging_bucket
+  logging_bucket = var.create_logging_bucket ? module.file_uploads_s3_logging_bucket.aws_logs_bucket : local.file_uploads_s3_bucket_logs
 
   cors_rules = var.cors_rules
 
@@ -21,7 +21,7 @@ module "file_uploads_s3_logging_bucket" {
   source  = "trussworks/logs/aws"
   version = "~> 10.0.0"
 
-  s3_bucket_name          = local.file_uploads_s3_logging_bucket
+  s3_bucket_name          = local.file_uploads_s3_bucket_logs
   s3_log_bucket_retention = var.s3_logs_retention_days
 
   default_allow = false

--- a/s3.tf
+++ b/s3.tf
@@ -16,7 +16,6 @@ module "file_uploads_s3_bucket" {
   }
 }
 
-# we use a separate access logging bucket for every environment
 module "file_uploads_s3_logging_bucket" {
   count   = var.create_logging_bucket ? 1 : 0
   source  = "trussworks/logs/aws"

--- a/variables.tf
+++ b/variables.tf
@@ -33,7 +33,6 @@ variable "lambda_s3_bucket" {
 variable "logging_bucket" {
   type        = string
   description = "The name of the S3 bucket used for S3 access logs."
-  default = ""
 }
 
 variable "create_logging_bucket" {

--- a/variables.tf
+++ b/variables.tf
@@ -30,6 +30,18 @@ variable "lambda_s3_bucket" {
   description = "The name of the S3 bucket where the lambda build artifact is stored"
 }
 
+variable "logging_bucket" {
+  type        = string
+  description = "The name of the S3 bucket used for S3 access logs."
+  default = ""
+}
+
+variable "create_logging_bucket" {
+  type = bool
+  description = "Whether to create a new bucket for S3 access logs."
+  default = false
+}
+
 variable "av_status_sns_arn" {
   type        = string
   description = "SNS topic ARN to publish scan results to"

--- a/variables.tf
+++ b/variables.tf
@@ -36,9 +36,9 @@ variable "logging_bucket" {
 }
 
 variable "create_logging_bucket" {
-  type = bool
+  type        = bool
   description = "Whether to create a new bucket for S3 access logs."
-  default = false
+  default     = false
 }
 
 variable "av_status_sns_arn" {

--- a/variables.tf
+++ b/variables.tf
@@ -33,6 +33,7 @@ variable "lambda_s3_bucket" {
 variable "logging_bucket" {
   type        = string
   description = "The name of the S3 bucket used for S3 access logs."
+  default     = ""
 }
 
 variable "create_logging_bucket" {


### PR DESCRIPTION
Currently, the module creates a separate logging bucket. This PR adds the ability to use an existing logs bucket.

It adds two variables:
- `logging_bucket`
- `create_logging_bucket`

`logging_bucket` can refer either to: (1) the name of an existing log bucket to use, or (2) the name of a new log bucket to create.