### PR TITLE
Module dependency

### DIFF
--- a/av.tf
+++ b/av.tf
@@ -21,6 +21,10 @@ module "s3_anti_virus" {
     Environment = var.environment
     Automation  = "Terraform"
   }
+
+  depends_on = [
+    module.file_uploads_s3_bucket,
+  ]
 }
 
 #


### PR DESCRIPTION
Add a `depends_on` relationship between the s3_anti_virus module and the file_uploads_s3_bucket module. Attempting to deploy terraform-aws-s3-file-uploads in a new environment generated a `Error: Failed getting S3 bucket: NotFound` on the file upload bucket.